### PR TITLE
Make amendment: Senior Treasurer changes require Junior Proctor's permission

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -74,7 +74,9 @@ Changes to the Repository may be proposed by any member during any regular meeti
 
 ## 9. Changes to the Constitution
 
- The Constitution may be amended at a General Meeting, with approval of at least two thirds of those present.
+The Constitution may be amended at a General Meeting, with approval of at least two thirds of those present.
+
+No amendment to this Constitution intended to remove the position of Senior Treasurer, to alter its prerogatives and duties, or to change the criteria and procedure for the appointment of a Senior Treasurer can be put to a vote without the prior written agreement of the Junior Proctor of the University of Cambridge.
 
 ## 10. Disciplinary Processes
 


### PR DESCRIPTION
Make constitution/non-constitutional change from meeting on 2018-MM-DD

This change was requested by the Junior Proctor of the University of
Cambridge  in an email to Stephen Christopher, the current Junior
Treasurer of Hackers at Cambridge on the 6th of February 2018.

It essentially ensures that any changes to the role of Senior Treasurer
require the written agreement of the Junior Proctor of the University of
Cambridge.

Proposed By Tom Read Cutting.

**Attendees**:
- Mara Mihali
- Eliot Lim
- Hari Prasad Chandrasekaran
- Timothy Lazarus
- Martin Hartt
- Jared Khan
- Tom Read Cutting
- Christian Silver
- Charlie Crisp
- Maximilian Ge
- Stephen Christopher
- Lucia Bura
- Raphael Schmetterling
- Robin McCorkell

**Votes For**: 14

**Votes Against**: 0

**Abstentions**: 0
