### PR TITLE
Add newly proposed members for meeting on 2018-03-13

### DIFF
--- a/members/members.yaml
+++ b/members/members.yaml
@@ -46,3 +46,27 @@ member:
 member:
   name: Stephen Christopher
   date: 2017-02-15
+member:
+  name: Mukul Rathi
+  date: 2018-03-13
+member:
+  name: Mara Mihali
+  date: 2018-03-13
+member:
+  name: Raphael Schmetterling
+  date: 2018-03-13
+member:
+  name: Eliot Lim
+  date: 2018-03-13
+member:
+  name: Hari Prasad
+  date: 2018-03-13
+member:
+  name: Patrick Ferris
+  date: 2018-03-13
+member:
+  name: Timothy Lazarus
+  date: 2018-03-13
+member:
+  name: Monitrice Lashe
+  date: 2018-03-13

--- a/members/members.yaml
+++ b/members/members.yaml
@@ -70,3 +70,6 @@ member:
 member:
   name: Monitrice Lashe
   date: 2018-03-13
+member:
+  name: Martin Hartt
+  date: 2018-03-13


### PR DESCRIPTION
Make non-constitutional change from meeting on 2018-03-13

Add new members to the society.

Proposed By Tom Read Cutting.

**Attendees**:
  - Tom Read Cutting: General Secretary
  - Jared Khan: Workshop Manager
  - Charlie Crisp: Social Media Manager
  - Christian Silver: Design Manager
  - Stephen Christopher: Junior Treasurer

**Votes For**: 5

**Votes Against**: 0

**Abstentions**: 0