### PR TITLE
Change the structure of the executive committee

### DIFF
--- a/committee/committee.yaml
+++ b/committee/committee.yaml
@@ -33,7 +33,7 @@ member:
   name: Eliot Lim
   role: General Officer
 member:
-  name: Hari Prasa
+  name: Hari Prasad
   role: General Officer
 member:
   name: Patrick Ferris
@@ -43,4 +43,7 @@ member:
   role: General Officer
 member:
   name: Monitrice Lashe
+  role: General Officer
+member:
+  name: Martin Hartt
   role: General Officer

--- a/committee/committee.yaml
+++ b/committee/committee.yaml
@@ -33,7 +33,7 @@ member:
   name: Eliot Lim
   role: General Officer
 member:
-  name: Hari Prasad
+  name: Hari Prasad Chandrasekaran
   role: General Officer
 member:
   name: Patrick Ferris

--- a/committee/committee.yaml
+++ b/committee/committee.yaml
@@ -1,4 +1,4 @@
-when: AGM on the 2017-05-24
+when: EGM on the 2018-03-13
 member:
   name: Tom Read Cutting
   role: General-Secretary
@@ -10,16 +10,37 @@ member:
   role: Senior Treasurer
 member:
   name: Jared Khan
-  role: Workshop Manager
+  role: General Officer
 member:
   name: Christian Silver
-  role: Design Manager
+  role: General Officer
 member:
   name: Lucia Bura
-  role: HaC Night Manager
+  role: General Officer
 member:
   name: Charlie Crisp
-  role: Social Media Manager
+  role: General Officer
 member:
-  name: Tristram Newman
-  role: Video Manager
+  name: Mukul Rathi
+  role: General Officer
+member:
+  name: Mara Mihali
+  role: General Officer
+member:
+  name: Raphael Schmetterling
+  role: General Officer
+member:
+  name: Eliot Lim
+  role: General Officer
+member:
+  name: Hari Prasa
+  role: General Officer
+member:
+  name: Patrick Ferris
+  role: General Officer
+member:
+  name: Timothy Lazarus
+  role: General Officer
+member:
+  name: Monitrice Lashe
+  role: General Officer

--- a/members/members.yaml
+++ b/members/members.yaml
@@ -46,3 +46,27 @@ member:
 member:
   name: Stephen Christopher
   date: 2017-02-15
+member:
+  name: Mukul Rathi
+  date: 2018-03-13
+member:
+  name: Mara Mihali
+  date: 2018-03-13
+member:
+  name: Raphael Schmetterling
+  date: 2018-03-13
+member:
+  name: Eliot Lim
+  date: 2018-03-13
+member:
+  name: Hari Prasad Chandrasekaran
+  date: 2018-03-13
+member:
+  name: Patrick Ferris
+  date: 2018-03-13
+member:
+  name: Timothy Lazarus
+  date: 2018-03-13
+member:
+  name: Monitrice Lashe
+  date: 2018-03-13


### PR DESCRIPTION
Make non-constitutional change from EGM on 2018-03-13

Reflects the fact that Tristram Newman has voluntarily stepped down from the executive committee.

Furthermore, all roles (baring constitutionally-required ones) are changed to "General Officer" to reflect the soon-to-be coming fact that the roles people assume will be more general-purpose.

The following members are added to the committee:

- Mukul Rathi
- Mara Mihali
- Raphael Schmetterling
- Eliot Lim
- Hari Prasa
- Patrick Ferris
- Timothy Lazarus
- Monitrice Lashe
- Martin Hartt

Proposed By Tom Read Cutting.

**Attendees**:

- Mara Mihali
- Eliot Lim
- Hari Prasad Chandrasekaran
- Timothy Lazarus
- Martin Hartt
- Jared Khan
- Tom Read Cutting
- Christian Silver
- Charlie Crisp
- Maximilian Ge
- Stephen Christopher

**Votes For**: 11

**Votes Against**: 0

**Abstentions**: 0
