### PR TITLE
Make constitution/non-constitutional change from meeting on 2020-06-30

### DIFF
--- a/members/members.yaml
+++ b/members/members.yaml
@@ -73,3 +73,6 @@ member:
 member:
   name: Martin Hartt
   date: 2018-03-13
+member:
+  name: Thomas Grant
+  date: 2020-06-30


### PR DESCRIPTION
Add new members to Hackers at Cambridge

Proposed By Patrick Ferris

Attendees:

    Eliot Lim: General Secretary
    Mukul Rathi: Committee Member
    Patrick Ferris: Junior Treasurer
    Thomas Grant: Committee Member

Votes For: 4

Votes Against: 0

Abstentions: 0

Make constitution/non-constitutional change from meeting on 2020-06-30